### PR TITLE
Fix for rank up loop

### DIFF
--- a/players/_rank.gsc
+++ b/players/_rank.gsc
@@ -19,10 +19,6 @@
 // Based on Reign of the Undead 2.1 created by Bipo and Etheross
 //
 
-#include common_scripts\utility;
-#include maps\mp\gametypes\_hud_util;
-#include scripts\include\hud;
-
 init()
 {
 	level.scoreInfo = [];
@@ -189,6 +185,8 @@ onPlayerConnect()
 	//for(;;)
 	//{
 	//	level waittill( "connected", player );
+	
+		self endon("disconnect");
 
 		self.pers["rankxp"] = self scripts\players\_persistence::statGet( "rankxp" );
 		rankId = self getRankForXp( self getRankXP() );
@@ -562,8 +560,10 @@ resetRank(delay) {
 
 updateRank( useWait )
 {
-	if (self.rankHacker)
-	return;
+	if (self.rankHacker || isdefined(self.updatingrank))
+		return false;
+	
+	self.updatingrank = true;
 	
 	if( !isDefined( useWait ) )
 		useWait = false;
@@ -573,7 +573,10 @@ updateRank( useWait )
 	
 	newRankId = self getRank();
 	if ( newRankId == self.pers["rank"] )
+	{
+		self.updatingrank = undefined;
 		return false;
+	}
 
 	oldRank = self.pers["rank"];
 	rankId = self.pers["rank"];
@@ -597,6 +600,7 @@ updateRank( useWait )
 	
 	self setRank( newRankId, self.pers["prestige"] );
 	self scripts\players\_classes::getSkillpoints(newRankId);
+	self.updatingrank = undefined;
 	return true;
 }
 
@@ -642,11 +646,7 @@ updateRankAnnounceHUD()
 	
 	if (subRank == 1)
 	{
-		for ( i = 0; i < level.players.size; i++ )
-		{
-			player = level.players[i];
-			player iprintln( &"RANK_PLAYER_WAS_PROMOTED", self, newRankName);
-		}
+		iprintln( &"RANK_PLAYER_WAS_PROMOTED", self.name, newRankName);
 	}
 }
 

--- a/players/_rank.gsc
+++ b/players/_rank.gsc
@@ -9,7 +9,7 @@
 // ##     ##  #######     ##     #######          ##     ## ########    ###     #######  ########  #######     ##    ####  #######  ##    ## 
 //
 // Reign of the Undead - Revolution ALPHA 0.7 by Luk and 3aGl3
-// Code contains parts made by Luk, Bipo, Etheross, Brax, Viking, Rycoon and Activision (no shit)
+// Code contains parts made by Luk, Bipo, Etheross, Brax, Viking, Rycoon, Dunciboy and Activision (no shit)
 // (Please keep in mind that I'm not the best coder and some stuff might be really dirty)
 // If you consider yourself more skilled at coding and would enjoy further developing this, contact me and we could improve this mod even further! (Xfire: lukluk1992 or at http://puffyforum.com)
 //
@@ -18,6 +18,10 @@
 //
 // Based on Reign of the Undead 2.1 created by Bipo and Etheross
 //
+
+#include common_scripts\utility;
+#include maps\mp\gametypes\_hud_util;
+#include scripts\include\hud;
 
 init()
 {

--- a/players/_rank.gsc
+++ b/players/_rank.gsc
@@ -183,6 +183,9 @@ getRankInfoLevel( rankId )
 	return int( tableLookup( "mp/ranktable.csv", 0, rankId, 13 ) );
 }
 
+/**
+ * Load the rank for every player that connects
+ */
 
 onPlayerConnect()
 {
@@ -190,7 +193,7 @@ onPlayerConnect()
 	//{
 	//	level waittill( "connected", player );
 	
-		self endon("disconnect");
+		self endon("disconnect"); //A user can lose connection exactly after connecting
 
 		self.pers["rankxp"] = self scripts\players\_persistence::statGet( "rankxp" );
 		rankId = self getRankForXp( self getRankXP() );
@@ -562,6 +565,11 @@ resetRank(delay) {
 	self notify("reset_rank_over");
 }
 
+/**
+ * Determine if player needs to be ranked up or not
+ * @return will send true if player needs rank up and false if not.
+ */
+
 updateRank( useWait )
 {
 	if (self.rankHacker || isdefined(self.updatingrank))
@@ -607,6 +615,10 @@ updateRank( useWait )
 	self.updatingrank = undefined;
 	return true;
 }
+
+/**
+ * Update rank in hud and announce rank up to other players
+ */
 
 updateRankAnnounceHUD()
 {

--- a/players/_rank.gsc
+++ b/players/_rank.gsc
@@ -193,7 +193,7 @@ onPlayerConnect()
 	//{
 	//	level waittill( "connected", player );
 	
-		self endon("disconnect"); //A user can lose connection exactly after connecting
+		self endon( "disconnect" ); //A user can lose connection exactly after connecting
 
 		self.pers["rankxp"] = self scripts\players\_persistence::statGet( "rankxp" );
 		rankId = self getRankForXp( self getRankXP() );
@@ -572,7 +572,7 @@ resetRank(delay) {
 
 updateRank( useWait )
 {
-	if (self.rankHacker || isdefined(self.updatingrank))
+	if ( self.rankHacker || isdefined( self.updatingrank ) )
 		return false;
 	
 	self.updatingrank = true;


### PR DESCRIPTION
This fix should solve this issue of ranking up multiple times to the same level.
To give an example your about to rank up 1 xp away from rank up and throw a monkey bomb.
You get 20 kills at the same frame time, this means your granted xp 20 times at the same time.
But because of this you will also be ranked up to level 20 for example 20 times.

Also removes and unneeded loop at line 653 to announce the rank up.

Fixed an if clause that  could end up with result null: if (  updateRank() ) which caused non-fatal script errors.

I did not change the documentation because it would take a long time and made this edit some probably like 6 months ago i will ad it later maybe.
